### PR TITLE
c/fix(Scroller): fix non-auto-starting scroller

### DIFF
--- a/src/lib/IONOS/components/explore/Scroller.svelte
+++ b/src/lib/IONOS/components/explore/Scroller.svelte
@@ -1,13 +1,14 @@
 <script lang="ts">
 	import { createEventDispatcher } from 'svelte';
+	import type ScrollerItem from './scrollerItem.d.ts';
 
 	const dispatcher = createEventDispatcher();
 
 	// Pixels per second
-	const speed = 25;
+	const speed: number = 25;
 
 	export let direction = 'left';
-	export let items;
+	export let items: ScrollerItem[] = [];
 
 	let el: HTMLElement|null = null;
 
@@ -17,9 +18,9 @@
 		}
 	}
 
-	let scrollWidth;
-	let fullWidth;
-	let duration;
+	let scrollWidth: number;
+	let fullWidth: number;
+	let duration: number;
 
 	$: {
 		scrollWidth = items.length > 0 ? el?.scrollWidth ?? 0 : 0;

--- a/src/lib/IONOS/components/explore/Scroller.svelte
+++ b/src/lib/IONOS/components/explore/Scroller.svelte
@@ -17,9 +17,15 @@
 		}
 	}
 
-	$: scrollWidth = el?.scrollWidth ?? 0;
-	$: fullWidth = scrollWidth / 2;
-	$: duration = fullWidth / speed;
+	let scrollWidth;
+	let fullWidth;
+	let duration;
+
+	$: {
+		scrollWidth = items.length > 0 ? el?.scrollWidth ?? 0 : 0;
+		fullWidth = scrollWidth / 2;
+		duration = fullWidth / speed;
+	}
 </script>
 
 <div


### PR DESCRIPTION
== Cause

The scroller animation did not start because the `animation-duration`
property had the value 0 initially.

This was caused by `el.scrollWidth` being 0 initially because there
were no elements in `items`, which was caused by PromptSelector loading
the items asynchroneously on mount.

== Fix

The reactive expression now incorporates the state of `items` for
recalculation.
