### PR TITLE
feat(Account): make delete account dependent on config

### DIFF
--- a/backend/open_webui/env.py
+++ b/backend/open_webui/env.py
@@ -424,3 +424,8 @@ if WEBHOOK_TIMEOUT_STR:
 IONOS_REGISTRATION_URL = os.environ.get("IONOS_REGISTRATION_URL", None)
 IONOS_LOGOUT_URL = os.environ.get("IONOS_LOGOUT_URL", None)
 IONOS_PASSWORD_RESET_URL = os.environ.get("IONOS_PASSWORD_RESET_URL", None)
+
+# Allow users to delete their accounts (default: False)
+IONOS_ACCOUNT_DELETION_ALLOWED = os.environ.get("IONOS_ACCOUNT_DELETION_ALLOWED", "false").lower() == "true"
+# Comma separated list of emails (default: empty)
+IONOS_ACCOUNT_DELETE_ALLOW_LIST = os.environ.get("IONOS_ACCOUNT_DELETE_ALLOW_LIST", "")

--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -282,6 +282,7 @@ from open_webui.env import (
     IONOS_REGISTRATION_URL,
     IONOS_LOGOUT_URL,
     IONOS_PASSWORD_RESET_URL,
+    IONOS_ACCOUNT_DELETION_ALLOWED,
 )
 
 
@@ -996,6 +997,7 @@ async def get_app_config(request: Request):
             "ionos_registration_url": IONOS_REGISTRATION_URL,
             "ionos_logout_url": IONOS_LOGOUT_URL,
             "ionos_password_reset_url": IONOS_PASSWORD_RESET_URL,
+            "ionos_user_account_deletion_allowed": IONOS_ACCOUNT_DELETION_ALLOWED,
             **(
                 {
                     "enable_channels": app.state.config.ENABLE_CHANNELS,

--- a/src/lib/IONOS/components/settings/Account.svelte
+++ b/src/lib/IONOS/components/settings/Account.svelte
@@ -6,9 +6,12 @@
 	import Button, { ButtonType } from '$lib/IONOS/components/common/Button.svelte'
 	import Confirm from '$lib/IONOS/components/common/Confirm.svelte';
 	import LoadingCover from '$lib/IONOS/components/common/LoadingCover.svelte';
-	import { user } from '$lib/stores';
+	import { config, user } from '$lib/stores';
 	import { resetPassword, deleteAccount } from '$lib/IONOS/services/account';
 	const i18n = getContext<Readable<I18Next>>('i18n');
+
+	const isAccountDeletionAllowedBackend = $config?.features?.ionos_user_account_deletion_allowed ?? false;
+	const isAccountDeletionAllowedFrontend = localStorage.accountDeletionAllowedOverride === 'true';
 
 	let confirmAccountDeletion = false;
 	let loading = false;
@@ -45,6 +48,7 @@
 			</Button>
 		</div>
 	</div>
+	{#if isAccountDeletionAllowedFrontend || isAccountDeletionAllowedBackend}
 	<div class="flex flex-row items-center h-10">
 		<div class="flex-grow">
 			{$i18n.t('Delete account', { ns: 'ionos' })}
@@ -57,6 +61,7 @@
 			</Button>
 		</div>
 	</div>
+	{/if}
 </div>
 
 {#if loading}

--- a/src/lib/stores/index.ts
+++ b/src/lib/stores/index.ts
@@ -209,6 +209,7 @@ type Config = {
 		ionos_registration_url: string|null;
 		ionos_logout_url: string|null;
 		ionos_password_reset_url: string|null;
+		ionos_user_account_deletion_allowed: boolean;
 	};
 	oauth: {
 		providers: {


### PR DESCRIPTION
To allow silent testing by us in the live system we add this config to
enable the feature only for allow listed email addresses.

== New configs

IONOS_ACCOUNT_DELETION_ALLOWED: true|false
IONOS_ACCOUNT_DELETE_ALLOW_LIST: comma separated list of allowed email addresses

== Frontend override config in localStorage

accountDeletionAllowedOverride: set to "true" overrides the backend config
IONOS_ACCOUNT_DELETION_ALLOWED to show the delete button.

The allow list can reject deletion if the account is not allow listed.

Refs: PRODAI-189