### PR TITLE
c/chore(github): add workflow to run unit tests

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -1,0 +1,32 @@
+name: Tests (backend)
+
+on:
+  push:
+    branches:
+      - ionos-dev
+      - 'feature/**'
+  pull_request:
+    branches:
+      - 'feature/**'
+
+jobs:
+  pytest:
+    name: Unit tests (Python)
+    runs-on: self-hosted
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
+ 
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 #v5.6.0
+        with:
+          python-version: 3.11
+ 
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r backend/requirements.txt
+ 
+      - name: pytest run
+        run: |
+          cd backend
+          pytest -o log_cli=true -o log_cli_level=INFO .


### PR DESCRIPTION
Problems spotted while testing: the installation of the dependency takes **several minutes**. Quite pointless to run tests taking a minute and having to wait 10 minutes for the installation of dependencies. :frowning_face: 