### PR TITLE
Reduce gap between assistant rows

### DIFF
--- a/src/lib/IONOS/components/explore/AgentSelector.svelte
+++ b/src/lib/IONOS/components/explore/AgentSelector.svelte
@@ -47,9 +47,9 @@
 	}
 </script>
 
-<div class="grid lg:grid-cols-4 md:grid-cols-2 gap-4 md:gap-y-0">
+<div class="grid py-12 lg:grid-cols-4 md:grid-cols-2 gap-4 gap-y-[20px]">
 	{#each shownAgents as { id, name, subtitle, description }}
-		<div class="min-h-96 flex items-center">
+		<div class="h-[280px] flex items-center">
 			<button
 				class="group w-56 hover:pb-0 duration-[500ms] transition-[padding] pb-4 mx-6 bg-white text-blue-800 text-left rounded-2xl shadow-xl group cursor-pointer"
 				data-id={id}
@@ -69,7 +69,7 @@
 					<h2 class="text-xs">
 						{subtitle}
 					</h2>
-					<div class="flex flex-col justify-between mt-0 overflow-hidden duration-[500ms] transition-[height,margin-top] h-0 group-hover:h-40 group-hover:mt-4 group-focus:h-40 group-focus:mt-4 focus-within:h-40 focus-within:mt-4 max-xs:h-40 max-xs:mt-4 max-xs:h-40 max-xs:mt-4">
+					<div class="flex flex-col justify-between mt-0 overflow-hidden duration-[500ms] transition-[height,margin-top] h-0 group-hover:h-[160px] group-hover:mt-4 group-focus:h-[160px] group-focus:mt-4 focus-within:h-[160px] focus-within:mt-4 max-xs:h-[160px] max-xs:mt-4 max-xs:h-[160px] max-xs:mt-4">
 						<p class="text-xs">
 							{description}
 						</p>

--- a/src/lib/IONOS/components/explore/AgentSelector.svelte
+++ b/src/lib/IONOS/components/explore/AgentSelector.svelte
@@ -51,11 +51,11 @@
 	{#each shownAgents as { id, name, subtitle, description }}
 		<div class="min-h-96 flex items-center">
 			<button
-				class="group w-56 hover:pb-0 duration-[500ms] transition-[padding] pb-4 mx-6 bg-white text-blue-800 text-left rounded-2xl shadow-xl transition group cursor-pointer"
+				class="group w-56 hover:pb-0 duration-[500ms] transition-[padding] pb-4 mx-6 bg-white text-blue-800 text-left rounded-2xl shadow-xl group cursor-pointer"
 				data-id={id}
 				on:click={() => dispatch('select', id)}
 			>
-				<div class="overflow-hidden transition-[width,height] duration-[500ms] h-36 rounded-t-2xl">
+				<div class="overflow-hidden h-36 rounded-t-2xl">
 					<img
 						class="h-full w-full object-cover rounded-2xl rounded-b-none"
 						src={`/avatars/${id}.jpg`}

--- a/src/lib/IONOS/components/explore/AgentSelector.svelte
+++ b/src/lib/IONOS/components/explore/AgentSelector.svelte
@@ -69,8 +69,8 @@
 					<h2 class="text-xs">
 						{subtitle}
 					</h2>
-					<div class="flex flex-col justify-between mt-0 overflow-hidden duration-[500ms] transition-[height,margin-top] h-0 group-hover:h-[160px] group-hover:mt-4 group-focus:h-[160px] group-focus:mt-4 focus-within:h-[160px] focus-within:mt-4 max-xs:h-[160px] max-xs:mt-4 max-xs:h-[160px] max-xs:mt-4">
-						<p class="text-xs">
+					<div class="flex flex-col mt-0 overflow-hidden duration-[500ms] transition-[height,margin-top] h-0 group-hover:h-[160px] group-hover:mt-4 group-focus:h-[160px] group-focus:mt-4 focus-within:h-[160px] focus-within:mt-4 max-xs:h-[160px] max-xs:mt-4 max-xs:h-[160px] max-xs:mt-4">
+						<p class="text-xs mb-7">
 							{description}
 						</p>
 						<div class="mb-4 text-center">


### PR DESCRIPTION
1. Change
  * **Changed card container (grid) to fixed row height, not min-height to prevent expanding it when cards increase height on hover**
  * Added grid Y-gap as declarative minimum gap between cards with one card expanded on hover
  * Change to pixel dimensions for card heights to make calculations easier
2. Drive-by cleanups and another fix: the **chat now button jumps** during the trnasition
