### PR TITLE
feat: Added Flag to disable DB Migrations

### DIFF
--- a/backend/dev.sh
+++ b/backend/dev.sh
@@ -1,11 +1,15 @@
 PORT="${PORT:-8080}"
 
-# if custom_resource_loader script exists, run it
-if [ -f "custom_resource_loader.py" ]; then
-  echo "Running maintenance script"
-  python custom_resource_loader.py
+if [ -z "$RUN_MIGRATIONS" ] || [ "$RUN_MIGRATIONS" = "true" ]; then
+  # if custom_resource_loader script exists, run it
+  if [ -f "custom_resource_loader.py" ]; then
+    echo "Running maintenance script"
+    python custom_resource_loader.py
+  else
+    echo "custom_resource_loader not found"
+  fi
 else
-  echo "custom_resource_loader not found"
+  echo "RUN_MIGRATIONS is either not set or set to false, skipping migrations."
 fi
 
 uvicorn open_webui.main:app --port $PORT --host 0.0.0.0 --forwarded-allow-ips '*' --reload

--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -64,7 +64,9 @@ def run_migrations():
         log.exception(f"Error running migrations: {e}")
 
 
-run_migrations()
+
+if os.getenv("RUN_MIGRATIONS", "true").lower() == "true":
+    run_migrations()
 
 
 class Config(Base):

--- a/backend/start.sh
+++ b/backend/start.sh
@@ -31,12 +31,16 @@ if test "$WEBUI_SECRET_KEY $WEBUI_JWT_SECRET_KEY" = " "; then
   WEBUI_SECRET_KEY=$(cat "$KEY_FILE")
 fi
 
-# if custom_resource_loader script exists, run it
-if [ -f "custom_resource_loader.py" ]; then
-  echo "Running maintenance script"
-  python custom_resource_loader.py
+if [ -z "$RUN_MIGRATIONS" ] || [ "$RUN_MIGRATIONS" = "true" ]; then
+  # if custom_resource_loader script exists, run it
+  if [ -f "custom_resource_loader.py" ]; then
+    echo "Running maintenance script"
+    python custom_resource_loader.py
+  else
+    echo "custom_resource_loader not found"
+  fi
 else
-  echo "custom_resource_loader not found"
+  echo "RUN_MIGRATIONS is either not set or set to false, skipping migrations."
 fi
 
 if [[ "${USE_OLLAMA_DOCKER,,}" == "true" ]]; then

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -1,6 +1,26 @@
 name: open-webui-dev
 
+# SQL custom_init.sql >
+# CREATE DATABASE openwebui_vector;
+# \c openwebui_vector
+# CREATE EXTENSION vector;
+
+
 services:
+
+#  postgresql:
+#    image: pgvector/pgvector:pg17
+#    environment:
+#      POSTGRES_USER: postgres
+#      POSTGRES_PASSWORD: pass
+#      POSTGRES_DB: postgres
+#    ports:
+#      - "5432:5432"
+#    volumes:
+#      - ./initdb.d/custom_init.sql:/docker-entrypoint-initdb.d/custom_init.sql
+#      - pgdata:/var/lib/postgresql/data
+
+
   frontend:
     build:
       context: .
@@ -38,6 +58,7 @@ services:
     env_file: ".env"
     environment:
       - ENV=dev
+      - RUN_MIGRATIONS=false
     ports:
       - "8080:8080"
     extra_hosts:
@@ -45,20 +66,43 @@ services:
     volumes:
       - ./backend:/app/backend
       - data:/app/backend/data
+    depends_on:
+      - backend-migrate  # wartet auf Migrationen
 
-  keycloak:
-    image: quay.io/keycloak/keycloak:26.0.7-0
-    command: ["start-dev", "--http-enabled=true", "--http-port=8079", "--log-level=info", "--import-realm"]
-    volumes:
-      - ./keycloak/realm-export.json:/opt/keycloak/data/import/realm-export.json
+  backend-migrate:
+    image: open-webui-dev-backend
+    env_file: ".env"
+    command: ["python", "custom_resource_loader.py"]
     environment:
-      # Needed to create a config from scratch. Causing errors when using --import-realm
-      # - KC_BOOTSTRAP_ADMIN_USERNAME=admin
-      # - KC_BOOTSTRAP_ADMIN_PASSWORD=admin
-      - KC_FEATURES=persistent-user-sessions
-    network_mode: host
-    ports:
-      - "8079:8079"
+      - ENV=dev
+      - RUN_MIGRATIONS=true
+    volumes:
+      - ./backend:/app/backend
+      - data:/app/backend/data
+
+
+#  tika:
+#    image: apache/tika:2.5.0.2-full
+#    ports:
+#      - "9998:9998"
+#    environment:
+#      - TIKA_LOG_LEVEL=INFO
+
+
+#  keycloak:
+#    image: quay.io/keycloak/keycloak:26.0.7-0
+#    command: ["start-dev", "--http-enabled=true", "--http-port=8079", "--log-level=info", "--import-realm"]
+#    volumes:
+#      - ./keycloak/realm-export.json:/opt/keycloak/data/import/realm-export.json
+#    environment:
+#      # Needed to create a config from scratch. Causing errors when using --import-realm
+#      # - KC_BOOTSTRAP_ADMIN_USERNAME=admin
+#      # - KC_BOOTSTRAP_ADMIN_PASSWORD=admin
+#      - KC_FEATURES=persistent-user-sessions
+#    network_mode: host
+#    ports:
+#      - "8079:8079"
  
 volumes:
   data: {}
+  pgdata: {}


### PR DESCRIPTION
Added new ENV:
RUN_MIGRATIONS 
- to control database migrations triggered by the app itself
- to control update of models and (functions) via custom_resources Added new maintenance container in docker-compose for dev

Currently Migrations are executed by default and need to be explictily disabled.

Refs:
  - PRODAI-379
