### PR TITLE
feat: redis lock for db migration

### DIFF
--- a/backend/dev.sh
+++ b/backend/dev.sh
@@ -1,15 +1,3 @@
 PORT="${PORT:-8080}"
 
-if [ -z "$RUN_MIGRATIONS" ] || [ "$RUN_MIGRATIONS" = "true" ]; then
-  # if custom_resource_loader script exists, run it
-  if [ -f "custom_resource_loader.py" ]; then
-    echo "Running maintenance script"
-    python custom_resource_loader.py
-  else
-    echo "custom_resource_loader not found"
-  fi
-else
-  echo "RUN_MIGRATIONS is either not set or set to false, skipping migrations."
-fi
-
 uvicorn open_webui.main:app --port $PORT --host 0.0.0.0 --forwarded-allow-ips '*' --reload

--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -30,7 +30,8 @@ from open_webui.env import (
     log,
 )
 from open_webui.internal.db import Base, get_db
-from open_webui.utils.redis import get_redis_connection
+from open_webui.utils.redis import get_redis_connection, get_sentinels_from_env
+from open_webui.utils.custom_resource_loader import start_sync
 
 
 class EndpointFilter(logging.Filter):
@@ -48,7 +49,7 @@ logging.getLogger("uvicorn.access").addFilter(EndpointFilter())
 
 # Function to run the alembic migrations
 def run_migrations():
-    log.info("Running migrations")
+    print("Running migrations")
     try:
         from alembic import command
         from alembic.config import Config
@@ -65,8 +66,32 @@ def run_migrations():
 
 
 
+def get_redis_conn():
+    """Get a Redis connection."""
+    if REDIS_URL:
+        return get_redis_connection(REDIS_URL, None, decode_responses=True)
+    elif REDIS_SENTINEL_HOSTS and REDIS_SENTINEL_PORT:
+        return get_redis_connection(
+            None, get_sentinels_from_env(REDIS_SENTINEL_HOSTS, REDIS_SENTINEL_PORT), decode_responses=True
+        )
+    else:
+        return None
+
+
 if os.getenv("RUN_MIGRATIONS", "true").lower() == "true":
-    run_migrations()
+    redisConn = get_redis_conn()
+    if redisConn is not None:
+        try:
+            with redisConn.lock('migrate_lock', timeout=60):
+                run_migrations()
+                start_sync()
+        except Exception as e:
+            log.exception(f"Error connecting to Redis: {e}")
+    else:
+        run_migrations()
+        start_sync()
+else:
+    print("Skipping migrations as RUN_MIGRATIONS is set to false.")
 
 
 class Config(Base):

--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -4,6 +4,7 @@ import os
 import shutil
 import base64
 import redis
+import traceback
 
 from datetime import datetime
 from pathlib import Path
@@ -62,8 +63,9 @@ def run_migrations():
 
         command.upgrade(alembic_cfg, "head")
     except Exception as e:
-        log.exception(f"Error running migrations: {e}")
-
+        print(f"ERROR: Error running migrations: {e}")
+        traceback.print_exc()
+        raise e
 
 
 def get_redis_conn():
@@ -78,20 +80,83 @@ def get_redis_conn():
         return None
 
 
-if os.getenv("RUN_MIGRATIONS", "true").lower() == "true":
-    redisConn = get_redis_conn()
-    if redisConn is not None:
-        try:
-            with redisConn.lock('migrate_lock', timeout=60):
-                run_migrations()
+def _run_migrations_with_lock(redis_conn):
+    """Handles the blocking lock logic specifically for migrations."""
+    print("Waiting to acquire blocking lock for migrations...")
+    try:
+        with redis_conn.lock('migrate_lock', timeout=300):
+            print("Acquired migration lock. Running migrations...")
+            run_migrations()
+            print("Migrations completed.")
+            return True
+    except Exception as e:
+        print(f"ERROR: An error occurred during the blocking migration process: {e}")
+        traceback.print_exc()
+        return False
+
+def _start_sync_with_lock(redis_conn):
+    """Handles the non-blocking lock logic specifically for the sync task."""
+    print("Attempting to acquire non-blocking lock for sync task...")
+    try:
+        sync_lock = redis_conn.lock('sync_lock', blocking=False, timeout=60)
+        if sync_lock.acquire():
+            print("Acquired sync lock. Starting sync process...")
+            try:
                 start_sync()
-        except Exception as e:
-            log.exception(f"Error connecting to Redis: {e}")
-    else:
+                print("Sync process started successfully.")
+            finally:
+                sync_lock.release()
+        else:
+            print("Sync lock is already held by another pod. Skipping on this instance.")
+    except Exception as e:
+        print(f"ERROR: An error occurred during the non-blocking sync process: {e}")
+        traceback.print_exc()
+
+def _run_tasks_without_redis():
+    """Runs tasks directly when Redis isn't available"""
+    print("WARNING: Redis not configured. Running all startup tasks directly without locks.")
+    try:
         run_migrations()
+    except Exception:
+        print("WARNING: Migrations failed. Skipping sync task.")
+        return
+    try:
         start_sync()
-else:
-    print("Skipping migrations as RUN_MIGRATIONS is set to false.")
+        print("Startup tasks completed successfully in single-instance mode.")
+    except Exception as e:
+        print(f"ERROR: An error occurred during startup tasks in single-instance mode: {e}")
+        traceback.print_exc()
+
+def run_startup_tasks_safely():
+    """
+    Main entrypoint for running startup tasks.
+    Orchestrates using Redis locks if available, or runs directly if not.
+    """
+    if os.getenv("RUN_MIGRATIONS", "true").lower() != "true":
+        print("Skipping startup tasks: RUN_MIGRATIONS is not 'true'.")
+        return
+
+    redis_conn = None
+    try:
+        redis_conn = get_redis_conn()
+    except Exception as e:
+        print("ERROR: Could not connect to the configured Redis instance.")
+        print("       To prevent potential race conditions, all migration and sync tasks will be skipped.")
+        print(f"       Underlying Error: {e}")
+        traceback.print_exc()
+        return
+
+    if redis_conn:
+        migrations_succeeded = _run_migrations_with_lock(redis_conn)
+        if migrations_succeeded:
+            _start_sync_with_lock(redis_conn)
+        else:
+            print("WARNING: Migrations failed. Skipping sync task to prevent further errors.")
+    else:
+        _run_tasks_without_redis()
+
+run_startup_tasks_safely()
+
 
 
 class Config(Base):

--- a/backend/open_webui/models/models.py
+++ b/backend/open_webui/models/models.py
@@ -15,9 +15,6 @@ from sqlalchemy.dialects import postgresql, sqlite
 from sqlalchemy import BigInteger, Column, Text, JSON, Boolean
 
 
-from open_webui.utils.access_control import has_access
-
-
 log = logging.getLogger(__name__)
 log.setLevel(SRC_LOG_LEVELS["MODELS"])
 
@@ -198,6 +195,7 @@ class ModelsTable:
     def get_models_by_user_id(
         self, user_id: str, permission: str = "write"
     ) -> list[ModelUserResponse]:
+        from open_webui.utils.access_control import has_access
         models = self.get_models()
         return [
             model

--- a/backend/open_webui/utils/custom_resource_loader.py
+++ b/backend/open_webui/utils/custom_resource_loader.py
@@ -3,6 +3,9 @@ import json
 import os
 import base64
 
+
+from open_webui.env import log
+
 from open_webui.models.models import (
     ModelForm,
     ModelMeta,
@@ -17,13 +20,12 @@ from open_webui.models.auths import (
     Auths,
 )
 
-from open_webui.models.users import Users
-
 from open_webui.utils.auth import (
     get_password_hash,
 )
 
-DEFAULT_RESOURCES_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'custom_resources')
+PROJECT_ROOT = os.path.abspath(os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
+DEFAULT_RESOURCES_PATH = os.path.join(PROJECT_ROOT, 'custom_resources')
 
 # Will be set in check_required_env_vars()
 resources_path = None
@@ -34,10 +36,10 @@ def load_json_file(file_path: str):
             data = json.load(file)
             return data
     except FileNotFoundError:
-        print(f"Error: File '{file_path}' not found.")
+        log.info(f"Error: File '{file_path}' not found.")
         return None
     except json.JSONDecodeError:
-        print(f"Error: Unable to parse JSON in file '{file_path}'.")
+        log.info(f"Error: Unable to parse JSON in file '{file_path}'.")
         return None
 
 def load_image_file_base64_string(file_path: str):
@@ -48,10 +50,10 @@ def load_image_file_base64_string(file_path: str):
                 base64_image_string = base64.b64encode(icon_data).decode('utf-8')
                 return f'data:image/png;base64,{base64_image_string}'
             else:
-                print(f"Error reading icon file '{file_path}'.")
+                log.info(f"Error reading icon file '{file_path}'.")
                 return None
     except FileNotFoundError:
-        print(f"Error: File '{file_path}' not found.")
+        log.info(f"Error: File '{file_path}' not found.")
         return None
 
 def load_db_models():
@@ -88,9 +90,9 @@ def handle_model_update(admin_user_id, db_models, json_models):
                 meta_data['profile_image_url'] = icon_data
                 model['meta'] = meta_data
             else:
-                print(f"Error reading icon file '{icon_path}'.")
+                log.info(f"Error reading icon file '{icon_path}'.")
         else:
-            print(f"Icon path not found in meta data.")
+            log.info(f"Icon path not found in meta data.")
 
 
     # Get Set of model which in exist in database but not in json
@@ -100,33 +102,33 @@ def handle_model_update(admin_user_id, db_models, json_models):
     # Get Set of model which in exist in both database and json
     model_update_set = db_model_id_set.intersection(json_model_id_set)
 
-    print(f"Found {len(model_delete_set)} model{'s' if len(model_delete_set) != 1 else ''} in the database that do{'es' if len(model_delete_set) == 1 else ''} not exist in the JSON file.")
+    log.info(f"Found {len(model_delete_set)} model{'s' if len(model_delete_set) != 1 else ''} in the database that do{'es' if len(model_delete_set) == 1 else ''} not exist in the JSON file.")
     for model_id in model_delete_set:
         result = delete_model_by_id(model_id)
         if result:
-            print(f"Model with id '{model_id}' deleted successfully.")
+            log.info(f"Model with id '{model_id}' deleted successfully.")
         else:
-            print(f"Error deleting model with id '{model_id}'.")
+            log.info(f"Error deleting model with id '{model_id}'.")
 
-    print(f"Found {len(model_create_set)} model{'s' if len(model_create_set) != 1 else ''} in the JSON file that do{'es' if len(model_create_set) == 1 else ''} not exist in the database.")
+    log.info(f"Found {len(model_create_set)} model{'s' if len(model_create_set) != 1 else ''} in the JSON file that do{'es' if len(model_create_set) == 1 else ''} not exist in the database.")
     for model in json_models:
         if model['id'] in model_create_set:
             form_data = getModelForm(model)
             result = Models.insert_new_model(form_data, admin_user_id)
             if result:
-                print(f"Model with id '{model['id']}' created successfully.")
+                log.info(f"Model with id '{model['id']}' created successfully.")
             else:
-                print(f"Error creating model with id '{model['id']}'.")
+                log.info(f"Error creating model with id '{model['id']}'.")
 
-    print(f"Found {len(model_update_set)} model{'s' if len(model_update_set) != 1 else ''} that exist in both the database and the JSON file.")
+    log.info(f"Found {len(model_update_set)} model{'s' if len(model_update_set) != 1 else ''} that exist in both the database and the JSON file.")
     for model in json_models:
         if model['id'] in model_update_set:
             form_data = getModelForm(model)
             result = update_model_by_id(model['id'], form_data)
             if result:
-                print(f"Model with id '{model['id']}' updated successfully.")
+                log.info(f"Model with id '{model['id']}' updated successfully.")
             else:
-                print(f"Error updating model with id '{model['id']}'.")
+                log.info(f"Error updating model with id '{model['id']}'.")
 
 
 def getModelForm(model_data: dict[str, any]):
@@ -193,18 +195,19 @@ def sync_admin_user() -> str:
     admin_email = os.getenv('ADMIN_EMAIL').lower()
     admin_password = os.getenv('ADMIN_PASSWORD')
 
+    from open_webui.models.users import Users
     admin = Users.get_user_by_email(admin_email)
     if admin:
         if not update_password(admin, admin_password):
             raise RuntimeError("Error updating admin user password.")
-        print("Admin user password updated successfully.")
+        log.info("Admin user password updated successfully.")
         return admin.id
     else:
         print("Admin user not found. Creating new admin user...")
         user_id = create_admin_user(admin_email, admin_password)
         if not user_id:
             raise RuntimeError("Error creating new admin user.")
-        print(f"Admin user created with id: {user_id}")
+        log.info(f"Admin user created with id: {user_id}")
         return user_id
 
 def check_required_env_vars() -> bool:
@@ -215,40 +218,37 @@ def check_required_env_vars() -> bool:
     admin_password = os.getenv('ADMIN_PASSWORD')
 
     if not admin_email:
-        print("Admin email (ADMIN_EMAIL) environment variable not set.")
+        log.info("Admin email (ADMIN_EMAIL) environment variable not set.")
         return False
 
     if not admin_password:
-        print("Admin password (ADMIN_PASSWORD) environment variable not set.")
+        log.info("Admin password (ADMIN_PASSWORD) environment variable not set.")
         return False
 
     # Use this if defined, otherwise fall back to default
     custom_resources_path_from_env = os.getenv('CUSTOM_RESOURCE_PATH')
 
     if custom_resources_path_from_env and os.path.exists(custom_resources_path_from_env):
-        print("Custom resource path set per environment variable.")
+        log.info("Custom resource path set per environment variable.")
         resources_path = custom_resources_path_from_env
     elif os.path.exists(DEFAULT_RESOURCES_PATH):
-        print("Using default custom resources path %s" % (DEFAULT_RESOURCES_PATH))
+        log.info("Using default custom resources path %s" % (DEFAULT_RESOURCES_PATH))
         resources_path = DEFAULT_RESOURCES_PATH
     else:
-        print("Nor per-environment not default custom resource path '%s' exist." % (DEFAULT_RESOURCES_PATH))
+        log.info("Neither per-environment nor default custom resource path '%s' exist." % (DEFAULT_RESOURCES_PATH))
         return False
 
-    print(f"Admin email: {admin_email}")
-    print(f"Admin password: {'*' * len(admin_password)}")
-    print(f"Custom resource path: {resources_path}")
+    log.info(f"Admin email: {admin_email}")
+    log.info(f"Admin password: {'*' * len(admin_password)}")
+
+    log.info(f"Custom resource path: {resources_path}")
     return True
 
-def main():
+def start_sync():
 
     if not check_required_env_vars():
-        print("Required environment variables not set. Skip syncing resources.")
+        log.info("Required environment variables not set. Skip syncing resources.")
         return
 
     admin_id = sync_admin_user()
     sync_models(admin_id)
-
-
-if __name__ == "__main__":
-    main()

--- a/backend/start.sh
+++ b/backend/start.sh
@@ -31,18 +31,6 @@ if test "$WEBUI_SECRET_KEY $WEBUI_JWT_SECRET_KEY" = " "; then
   WEBUI_SECRET_KEY=$(cat "$KEY_FILE")
 fi
 
-if [ -z "$RUN_MIGRATIONS" ] || [ "$RUN_MIGRATIONS" = "true" ]; then
-  # if custom_resource_loader script exists, run it
-  if [ -f "custom_resource_loader.py" ]; then
-    echo "Running maintenance script"
-    python custom_resource_loader.py
-  else
-    echo "custom_resource_loader not found"
-  fi
-else
-  echo "RUN_MIGRATIONS is either not set or set to false, skipping migrations."
-fi
-
 if [[ "${USE_OLLAMA_DOCKER,,}" == "true" ]]; then
     echo "USE_OLLAMA is set to true, starting ollama serve."
     ollama serve &


### PR DESCRIPTION
- Added Redis Locking to ensure only one process is updating the database at a time
- Moved custom_resource_loader into utils package
- customer_resource_loader is now executed after the db migration and not part of the startup_script

- **Differentiated Strategies**:
  - Uses a **blocking** lock for migrations, forcing other pods to wait for this critical step to complete before they proceed.
  - Uses a **non-blocking** lock for the subsequent sync task, allowing only one pod to trigger it without delaying others.

Refs:
- PRODAI-379