### PR TITLE
c/fix(services/survey): fix empty page on logo click

### DIFF
--- a/src/lib/IONOS/services/survey.spec.ts
+++ b/src/lib/IONOS/services/survey.spec.ts
@@ -53,6 +53,10 @@ describe('suvey', () => {
 			expect(buildSurveyUrl(user)).toBe(`${surveyUrl}?urlVar01=DE&urlVar02=${userId}&urlVar03=Product`);
 		});
 
+		it('should return null if the user is null', async () => {
+			expect(buildSurveyUrl(null)).toBe(null);
+		});
+
 		it('should return null if the survey URL is null', async () => {
 			surveyUrl = null;
 			expect(buildSurveyUrl(user)).toBe(null);

--- a/src/lib/IONOS/services/survey.ts
+++ b/src/lib/IONOS/services/survey.ts
@@ -2,14 +2,14 @@ import { get } from 'svelte/store';
 import type { SessionUser } from '$lib/stores';
 import { config } from '$lib/stores';
 
-export const buildSurveyUrl = (user: SessionUser): string|null => {
+export const buildSurveyUrl = (user: SessionUser|null): string|null => {
 	const surveyUrl = get(config)?.features?.ionos_survey_new_users_url ?? null;
 
 	if (surveyUrl === null) {
 		return null;
 	}
 
-	if (!user.pseudonymized_user_id) {
+	if (!user?.pseudonymized_user_id) {
 		return null;
 	}
 


### PR DESCRIPTION
## Steps to reproduce

1. Be logged out
2. Click the logo
3. Expected: reload/no-op/maybe login
4. Actual: page is empty, error in the console

## Cause

Since PRODAI-253 the Settings dialog is always rendered, only its show
state toggled. Thus, it references $user, which is null if logged out.

## Fix

The survey service can now handle null users.

Refs: SMBMOCQA-8551
