### PR TITLE
c/fix(Chat): fix empty no-op "New Chat" button in certain states

### DIFF
--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -99,6 +99,11 @@
 
 	let loading = false;
 
+	export function newChat() {
+		chatId.set('');
+		initNewChat();
+	}
+
 	const eventTarget = new EventTarget();
 	let controlPane;
 	let controlPaneComponent;


### PR DESCRIPTION
## Steps to reproduce

1. Start with an empty chat (i.e. either be logged in and open /) or open an existing chat and click new chat
2. Enter a prompt, send it and wait for a response
3. Click new chat button
4. Expected: an empty chat is started
5. Actual: nothing happens, one remains in the previous chat; an error is logged to the Devtools

## Fix

Fixed by reproducing change from

   2510fa0162285b7c8275424e144b657052cfdf12
   chore(Chat): start new chat though explicit function call

that got accidentally lost during the last merge from upstream in

   bbc3bf5704862aef7a2cabc696f85d01f363c4eb
   Merge tag 'v0.6.5' into feature/upgrade-to-0-6-5

Refs: SMBMOCQA-8556
