### PR TITLE
Fix "new chat" for top right mobile + drive-by chore

### DIFF
--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -1482,8 +1482,6 @@
 					scrollToBottom();
 
 					await sendPromptSocket(_history, model, responseMessageId, _chatId);
-
-					if (chatEventEmitter) clearInterval(chatEventEmitter);
 				} else {
 					toast.error($i18n.t(`Model {{modelId}} not found`, { modelId }));
 				}

--- a/src/lib/components/chat/Navbar.svelte
+++ b/src/lib/components/chat/Navbar.svelte
@@ -177,16 +177,19 @@
 
 				{#if $user !== undefined && $user !== null}
 					{#if $mobile}
-						<a
+						<button
 							id="sidebar-new-chat-button"
 							class="{$showSidebar ? 'flex-grow' : ''} flex space-x-3 rounded-sm p-2.5 bg-transparent text-blue-800 hover:bg-gray-200 dark:hover:bg-gray-900 transition no-drag-region"
-							href="/"
+							on:click={async () => {
+								await goto('/');
+								initNewChat();
+							}}
 							draggable="false"
 						>
 							<div class="self-center">
 								<PenSquare />
 							</div>
-						</a>
+						</button>
 					{:else}
 						<UserMenu
 							className="max-w-[200px]"


### PR DESCRIPTION
# Fix

## Steps to reproduce

1. Switch to mobile
2. Go to the chat index page (empty chat)
3. Enter a message, send it and wait for a response
4. Observation: the URL changes to /c/<UUID>
5. Click "New Chat" in the top right corner
6. Expected: an empty chat is shown (chat index) and we're at /
7. Actual: the chat remains but we're at /

## The fix

The routing of Open WebUI seems to be broken in some sense as
navigations sometimes do not suffice to set a proper chat state.

In some cases explicit function calls to Chat.initNewChat() are
required.

Until the routing is fixed this remains the fix.

Refs: SMBMOCQA-8556

# Chore

Remove of access to undefined var