### PR TITLE
fix: Delete Chat with knowledge reference

### DIFF
--- a/backend/open_webui/routers/chats.py
+++ b/backend/open_webui/routers/chats.py
@@ -498,8 +498,9 @@ async def delete_chat_by_id(request: Request, id: str, user=Depends(get_verified
 
         for file in chat.chat.get("files", []):
             file_id = file.get("id", None)
+            file_type = file.get("type", None)
             collection = file.get("collection",None)
-            if file_id and not collection:
+            if file_id and (collection is None and file_type != "collection"):
                 result = await delete_file_by_id(file_id,user)
                 if not result:
                     raise HTTPException(


### PR DESCRIPTION
Files changed:
- routers/chats.py

Extended condition to check if referenced file is a knowledge base or belongs to knowledge base Fixes issue where chats can't be deleted if a knowledge base is directly referenced