### PR TITLE
c/fix(TermsMenu): fix unreliable unreliable access to $i18n

### DIFF
--- a/src/lib/IONOS/components/TermsMenu.svelte
+++ b/src/lib/IONOS/components/TermsMenu.svelte
@@ -16,7 +16,9 @@
 
 	const i18n = getContext<Readable<I18Next>>('i18n');
 
-	let links: {label: string, url: string}[] = [
+	let links: {label: string, url: string}[] = [];
+
+	$: links = [
 		{
 			label: $i18n.t('bflUsePolicyLinkText', { ns: 'ionos' }),
 			url: $i18n.t('bflUsePolicyLinkUrl', { ns: 'ionos' })


### PR DESCRIPTION
## Steps to reproduce

1. Open new browser window as unauthenticated user or in incognito window
2. Open <host>/explore
3. Open Terms and conditions menu at the bottom of the page
4. Expected: All text and links are human readable and correct
5. Actual: some text have technical names like "bflUsePolicyLinkText" and URLs are wrong
 
## The fix
    
The store might not be initialized for all code paths. Subscribing to
the i18n store in the component render phase may lead to an uninitialized
store value.

Refs: SMBMOCQA-8552
