### PR TITLE
fix: chat search

### DIFF
--- a/backend/open_webui/migrations/versions/671df0e5af6e_update_postgres_chat_table.py
+++ b/backend/open_webui/migrations/versions/671df0e5af6e_update_postgres_chat_table.py
@@ -1,0 +1,96 @@
+"""Update postgres chat table
+
+Revision ID: 671df0e5af6e
+Revises: 3781e22d8b01
+Create Date: 2025-08-29 10:01:31.009079
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.sql import table, select, update
+import json
+
+revision = "671df0e5af6e"
+down_revision = "3781e22d8b01"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    """
+    Upgrades the 'chat' column from JSON to JSONB if the database is PostgreSQL.
+    """
+    # Get the underlying connection to check the dialect
+    conn = op.get_bind()
+
+    # This migration is only for PostgreSQL
+    if conn.dialect.name != "postgresql":
+        print("Skipping migration: Not a PostgreSQL database.")
+        return
+
+    from sqlalchemy.dialects.postgresql import JSONB
+    # Inspect the database to check the current column type
+    inspector = sa.inspect(conn)
+    columns = inspector.get_columns("chat")
+    column_info = next((c for c in columns if c["name"] == "chat"), None)
+
+    if not column_info:
+        print("Skipping migration: Column 'chat' not found in table 'chat'.")
+        return
+
+    # Check if the column type is JSON before altering.
+    # The type from the inspector for 'json' is JSON, not a specific dialect class.
+    # We can check the string representation to be sure.
+    if str(column_info["type"]).upper() == "JSON":
+        print("Altering 'chat.chat' column from JSON to JSONB.")
+        op.alter_column(
+            "chat",
+            "chat",
+            existing_type=sa.JSON(),
+            type_=JSONB,
+            postgresql_using="chat::jsonb",  # Required for casting data
+        )
+    else:
+        print(
+            f"Skipping migration: 'chat.chat' column is not of type JSON. "
+            f"(Current type: {column_info['type']})"
+        )
+
+def downgrade():
+    """
+    Downgrades the 'chat' column from JSONB back to JSON if the database is PostgreSQL.
+    """
+    # Get the underlying connection to check the dialect
+    conn = op.get_bind()
+
+    # This migration is only for PostgreSQL
+    if conn.dialect.name != "postgresql":
+        print("Skipping downgrade: Not a PostgreSQL database.")
+        return
+
+    from sqlalchemy.dialects.postgresql import JSONB
+    # Inspect the database to check the current column type
+    inspector = sa.inspect(conn)
+    columns = inspector.get_columns("chat")
+    column_info = next((c for c in columns if c["name"] == "chat"), None)
+
+    if not column_info:
+        print("Skipping downgrade: Column 'chat' not found in table 'chat'.")
+        return
+
+    # Check if the column type is JSONB before altering it back.
+    if isinstance(column_info["type"], JSONB):
+        print("Altering 'chat.chat' column from JSONB to JSON.")
+        op.alter_column(
+            "chat",
+            "chat",
+            existing_type=postgresql.JSONB,
+            type_=sa.JSON(),
+            postgresql_using="chat::json",  # Required for casting data
+        )
+    else:
+        print(
+            f"Skipping downgrade: 'chat.chat' column is not of type JSONB. "
+            f"(Current type: {column_info['type']})"
+        )

--- a/backend/open_webui/models/chats.py
+++ b/backend/open_webui/models/chats.py
@@ -629,7 +629,7 @@ class ChatTable:
                             """
                             EXISTS (
                                 SELECT 1
-                                FROM json_array_elements(Chat.chat->'messages') AS message
+                                FROM jsonb_array_elements(Chat.chat->'messages') AS message
                                 WHERE LOWER(message->>'content') LIKE '%' || :search_text || '%'
                             )
                             """
@@ -644,7 +644,7 @@ class ChatTable:
                             """
                             NOT EXISTS (
                                 SELECT 1
-                                FROM json_array_elements_text(Chat.meta->'tags') AS tag
+                                FROM jsonb_array_elements_text(Chat.meta->'tags') AS tag
                             )
                             """
                         )
@@ -657,7 +657,7 @@ class ChatTable:
                                     f"""
                                     EXISTS (
                                         SELECT 1
-                                        FROM json_array_elements_text(Chat.meta->'tags') AS tag
+                                        FROM jsonb_array_elements_text(Chat.meta->'tags') AS tag
                                         WHERE tag = :tag_id_{tag_idx}
                                     )
                                     """
@@ -747,7 +747,7 @@ class ChatTable:
                 # PostgreSQL JSON query for tags within the meta JSON field (for `json` type)
                 query = query.filter(
                     text(
-                        "EXISTS (SELECT 1 FROM json_array_elements_text(Chat.meta->'tags') elem WHERE elem = :tag_id)"
+                        "EXISTS (SELECT 1 FROM jsonb_array_elements_text(Chat.meta->'tags') elem WHERE elem = :tag_id)"
                     )
                 ).params(tag_id=tag_id)
             else:
@@ -801,7 +801,7 @@ class ChatTable:
                 # PostgreSQL JSONB support for querying the tags inside the `meta` JSON field
                 query = query.filter(
                     text(
-                        "EXISTS (SELECT 1 FROM json_array_elements_text(Chat.meta->'tags') elem WHERE elem = :tag_id)"
+                        "EXISTS (SELECT 1 FROM jsonb_array_elements_text(Chat.meta->'tags') elem WHERE elem = :tag_id)"
                     )
                 ).params(tag_id=tag_id)
 

--- a/backend/open_webui/models/chats.py
+++ b/backend/open_webui/models/chats.py
@@ -619,7 +619,7 @@ class ChatTable:
                     )
 
             elif dialect_name == "postgresql":
-                # PostgreSQL relies on proper JSON query for search
+                # PostgreSQL relies on proper JSONB query for search
                 query = query.filter(
                     (
                         Chat.title.ilike(
@@ -644,7 +644,7 @@ class ChatTable:
                             """
                             NOT EXISTS (
                                 SELECT 1
-                                FROM jsonb_array_elements_text(Chat.meta->'tags') AS tag
+                                FROM json_array_elements_text(Chat.meta->'tags') AS tag
                             )
                             """
                         )
@@ -657,7 +657,7 @@ class ChatTable:
                                     f"""
                                     EXISTS (
                                         SELECT 1
-                                        FROM jsonb_array_elements_text(Chat.meta->'tags') AS tag
+                                        FROM json_array_elements_text(Chat.meta->'tags') AS tag
                                         WHERE tag = :tag_id_{tag_idx}
                                     )
                                     """
@@ -747,7 +747,7 @@ class ChatTable:
                 # PostgreSQL JSON query for tags within the meta JSON field (for `json` type)
                 query = query.filter(
                     text(
-                        "EXISTS (SELECT 1 FROM jsonb_array_elements_text(Chat.meta->'tags') elem WHERE elem = :tag_id)"
+                        "EXISTS (SELECT 1 FROM json_array_elements_text(Chat.meta->'tags') elem WHERE elem = :tag_id)"
                     )
                 ).params(tag_id=tag_id)
             else:
@@ -798,10 +798,10 @@ class ChatTable:
                 ).params(tag_id=tag_id)
 
             elif db.bind.dialect.name == "postgresql":
-                # PostgreSQL JSONB support for querying the tags inside the `meta` JSON field
+                # PostgreSQL JSON support for querying the tags inside the `meta` JSON field
                 query = query.filter(
                     text(
-                        "EXISTS (SELECT 1 FROM jsonb_array_elements_text(Chat.meta->'tags') elem WHERE elem = :tag_id)"
+                        "EXISTS (SELECT 1 FROM json_array_elements_text(Chat.meta->'tags') elem WHERE elem = :tag_id)"
                     )
                 ).params(tag_id=tag_id)
 


### PR DESCRIPTION
Changed all Postgres chat queries in modesl/chats from using json to jsonb 
Added new Database Migration revision File to convert field type from json to jsonb to macht QA and PROD

How to reproduce:
Have the field chat in the table chat as type jsonb and use database queries with json_array_elements in models/chats)
