### PR TITLE
fix(requirements.txt): set posthog version < 6.0

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -45,6 +45,7 @@ langchain-community==0.3.18
 
 fake-useragent==2.1.0
 chromadb==0.6.3
+posthog<6.0.0
 pymilvus==2.5.0
 qdrant-client~=1.12.0
 opensearch-py==2.8.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ dependencies = [
 
     "fake-useragent==2.1.0",
     "chromadb==0.6.3",
+    "posthog<6.0.0",
     "pymilvus==2.5.0",
     "qdrant-client~=1.12.0",
     "opensearch-py==2.8.0",


### PR DESCRIPTION
# Fix

## Error

The application would log the error message

```
ERROR [chromadb.telemetry.product.posthog] Failed to send telemetry event ClientStartEvent: capture() takes 1 positional argument but 3 were given
```

on startup. This is due to the newest version of posthog (6.x) not being API compatible with the installed ChromaDB version.

## Cause

This is due to the Dockerfile always installing versions according to requirements.txt, uv.lock is not regarded.

## Note

Coincidentally discovered while changing the Dockerfile (while a cached layer could no longer be used).

## See also
    
* https://github.com/chroma-core/chroma/issues/4966
* https://github.com/open-webui/open-webui/issues/15673

Refs: PRODAI-421

# To test

1. Re-build the container image (i.e. `podman-compose ... build --no-cache`)
2. Look for the log message during container start