### PR TITLE
fix(+layout): don't redirect fresh users to Showroom

### DIFF
--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -64,7 +64,7 @@
 		if ($user === undefined || $user === null) {
 			await goto('/auth');
 		} else if (!await hasChats() && !hasStoredState()) {
-			window.location = UNAUTHENTICATED_USERS_TARGET;
+			window.location = '/explore';
 			return;
 		} else if (['user', 'admin'].includes($user?.role)) {
 			try {


### PR DESCRIPTION
New users have no chats, but should not be redirected to the showroom.

This fixes a change introduced with:

   4d188c344f5476d0953b2c35f58d6f5eae95f9e7
   feat(frontend): send unauthenticated users to an external URL

Refs: PRODAI-483
